### PR TITLE
Add missing guides

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,9 +5,10 @@
     - [ACRE](guides/acre.md)
     - [Arma](guides/arma.md)
     - [Formacje](guides/formations.md)
+    - [Poradnik dla nowych](guides/rookieguide.md)
     - [Robienie Misji](guides/missionmaking.md)
-    - [Symlink - ArmA SSD, mody HDD](https://drive.google.com/file/d/1lWbsHtAd6JXc7X-ZiMUpWLUAMQwwKrw9/view)
-    - [Wzywanie artylerii](https://drive.google.com/file/d/17DtQ8Z-7kXtwKS9dSXE29iuRrXvg9yse/view)
+    - [Symlink - ArmA SSD, mody HDD](guides/symlinks)
+    - [Wzywanie artylerii](guides/artillerycall.md)
 - **Rozwiązywanie problemów**
     - [ACRE](troubleshooting/acre.md)
     - [Arma](troubleshooting/arma.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,6 +6,8 @@
     - [Arma](guides/arma.md)
     - [Formacje](guides/formations.md)
     - [Robienie Misji](guides/missionmaking.md)
+    - [Symlink - ArmA SSD, mody HDD](https://drive.google.com/file/d/1lWbsHtAd6JXc7X-ZiMUpWLUAMQwwKrw9/view)
+    - [Wzywanie artylerii](https://drive.google.com/file/d/17DtQ8Z-7kXtwKS9dSXE29iuRrXvg9yse/view)
 - **Rozwiązywanie problemów**
     - [ACRE](troubleshooting/acre.md)
     - [Arma](troubleshooting/arma.md)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,7 +7,7 @@
     - [Formacje](guides/formations.md)
     - [Poradnik dla nowych](guides/rookieguide.md)
     - [Robienie Misji](guides/missionmaking.md)
-    - [Symlink - ArmA SSD, mody HDD](guides/symlinks)
+    - [Symlink - ArmA SSD, mody HDD](guides/symlinks.md)
     - [Wzywanie artylerii](guides/artillerycall.md)
 - **Rozwiązywanie problemów**
     - [ACRE](troubleshooting/acre.md)

--- a/docs/guides/artillerycall.md
+++ b/docs/guides/artillerycall.md
@@ -1,0 +1,7 @@
+# Wzywanie artylerii
+
+## Wstęp
+
+Poradnik opracowany z myślą o graczach, którzy jako BPP (oddziały piechoty) mają aspiracje większe, niż strzelanie do krzaków i wywalania się na pierwszym kontakcie. Zajmuje się on zagadnieniem efektywnej współpracy piechurów oraz jednostki wsparcia - artylerii. Twórcą poradnika jest @Jabar.
+
+[Być jak KWK Wujek - wzywanie artylerii na pozycje wroga](https://drive.google.com/file/d/17DtQ8Z-7kXtwKS9dSXE29iuRrXvg9yse/view)

--- a/docs/guides/rookieguide.md
+++ b/docs/guides/rookieguide.md
@@ -1,0 +1,7 @@
+# Poradnik dla rekrutów
+
+## Wstęp
+
+Poradnik został opracowany z myślą o graczach dopiero rozpoczynających członkostwo w naszej grupie - jego zamiarem jest poprowadzenie was przez rękę przez wszystkie meandry konfigurowania Army i radzenia sobie z wypracowanymi wewnątrz grupy systemami, do których należą między innymi zasady zapisywania się na misję. Poszczególne kroki są dokładnie opisane, te bardziej wymagające popieramy zrzutami ekranów, znajdziecie w nim również podstawowe FAQ dotyczące zagadnień ogólnych. W razie jakichkolwiek problemów ze zrozumieniem treści poradnika kontaktujcie się ze swoimi opiekunami Rekruterami, lub uderzajcie do jego twórcy na Discordzie - @Nakimeteles.
+
+[Przejdź do poradnika dla rekrutów](https://docs.google.com/document/d/1nOPqnTeu9Flph8oBtN2FFMQ5dUvwFet_Y80uH1ckp1s/edit?usp=sharing)

--- a/docs/guides/symlinks.md
+++ b/docs/guides/symlinks.md
@@ -1,0 +1,7 @@
+# Symlinki
+
+## Wstęp
+
+Poradnik został opracowany z myślą o graczach, którzy chcieliby zaoszczędzić precjozo jakim jest wolna przestrzeń na ich dyskach SSD, ale wciąż posiadać Armę na swoim szybszym dysku. Pokazuje on jak osiągnąć zamierzony cel przerzucając często spore paczki modów na dysk HDD i tworząc do nich linki. Twórcą poradnika jest @Renchon. 
+
+  [Symlink - ArmA SSD, mody HDD](https://drive.google.com/file/d/1lWbsHtAd6JXc7X-ZiMUpWLUAMQwwKrw9/view)

--- a/docs/main/101.md
+++ b/docs/main/101.md
@@ -1,6 +1,8 @@
 # ArmaForces 101
 
-# Przed dołączeniem
+# Przed dołączeniem - [Poradnik na 101](https://docs.google.com/document/d/1nOPqnTeu9Flph8oBtN2FFMQ5dUvwFet_Y80uH1ckp1s/edit?usp=sharing)
+
+Od deski do deski zapoznaj się z [Poradnikiem na 101 dla trzody i kaszy gryczanej](https://docs.google.com/document/d/1nOPqnTeu9Flph8oBtN2FFMQ5dUvwFet_Y80uH1ckp1s/edit?usp=sharing). Pokrywa on podstawowe zagadnienia pokroju zapisywania się na pierwszą misję i instalacji odpowiednich modów, z którymi każdy rekrut powinien się zapoznać. 
 
 ## Jak przebindować klawisz
 

--- a/docs/main/101.md
+++ b/docs/main/101.md
@@ -2,7 +2,9 @@
 
 # Przed dołączeniem
 
-Od deski do deski zapoznaj się z [Poradnikiem na 101 dla trzody i kaszy gryczanej](https://docs.google.com/document/d/1nOPqnTeu9Flph8oBtN2FFMQ5dUvwFet_Y80uH1ckp1s/edit?usp=sharing). Pokrywa on podstawowe zagadnienia pokroju zapisywania się na pierwszą misję i instalacji odpowiednich modów, z którymi każdy rekrut powinien się zapoznać. 
+## Poradnik dla świeżych rekrutów
+
+Od deski do deski zapoznaj się z [Poradnikiem dla rekrutów](../guides/rookieguide.md). Pokrywa on podstawowe zagadnienia pokroju zapisywania się na pierwszą misję i instalacji odpowiednich modów, z którymi każdy rekrut powinien się zapoznać. Jego znajomość pozwoli wam zaznajomić się z całym procesem zachodzącym po udanej rekrutacji, który zaprowadzi was do waszej pierwszej, oficjalnej misji w naszej grupie. 
 
 ## Jak przebindować klawisz
 

--- a/docs/main/101.md
+++ b/docs/main/101.md
@@ -1,6 +1,6 @@
 # ArmaForces 101
 
-# Przed dołączeniem - [Poradnik na 101](https://docs.google.com/document/d/1nOPqnTeu9Flph8oBtN2FFMQ5dUvwFet_Y80uH1ckp1s/edit?usp=sharing)
+# Przed dołączeniem
 
 Od deski do deski zapoznaj się z [Poradnikiem na 101 dla trzody i kaszy gryczanej](https://docs.google.com/document/d/1nOPqnTeu9Flph8oBtN2FFMQ5dUvwFet_Y80uH1ckp1s/edit?usp=sharing). Pokrywa on podstawowe zagadnienia pokroju zapisywania się na pierwszą misję i instalacji odpowiednich modów, z którymi każdy rekrut powinien się zapoznać. 
 


### PR DESCRIPTION
March towards centralized source of guidelines for AF players. This change will:
- add Renchon's SYMLINK guide to sidebar
- add Jabar's BYĆ JAK KWK WUJEK guide to sidebar
- add links to and mentions of Poradnik dla Ziemniaków in proper places (ArmaForces101, i.e. main wiki page)