### PR TITLE
Disable data links compilation

### DIFF
--- a/docs/guides/missionmaking.md
+++ b/docs/guides/missionmaking.md
@@ -194,7 +194,7 @@ Następnie zadowolony odpalisz misję na serwerze i zobaczysz, że Twoje własne
 
 ## **Misja pokazowa**
 
-[DO POBRANIA TUTAJ](docs/_data/guides/missionmaking/MisjaTutorial.zip)
+[DO POBRANIA TUTAJ](/_data/guides/missionmaking/MisjaTutorial.zip)
 
 Na potrzeby tego poradnika została przygotowana "misja", żeby bez nadmiaru informacji można było zapoznać się z częściami składowymi misji i pokazać że trzeba relatywnie niewiele aby misja była grywalna. Oczywiście, żeby to była dobra misja trzeba czegoś więcej niż kilku botów i zadań.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,10 @@
             homepage: "main/101.md",
             loadSidebar: true,
             subMaxLevel: 2,
-            themeColor: "#2684C1"
+            themeColor: "#2684C1",
+            noCompileLinks: [
+                '/_data/.*'
+            ]
         }
     </script>
     <script src="//unpkg.com/docsify/lib/docsify.min.js" data-ga="UA-156451763-3"></script>


### PR DESCRIPTION
When merged this PR will:
- Disable adding `#/` when linking to `_data/`.
- Fix mission tutorial example mission download link.

Closes #14.